### PR TITLE
Add Root Dockerfile to Run a Docker Container Without VSCode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Base image: Ubuntu 20.04 with ROS2 Galactic installed
-FROM ros:galactic
+FROM ros:foxy
 
 # Install dependencies from apt
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+#This Dockerfile differs from the .devcontainer/Dockerfile because this one does not depend on VSCode to inject the
+#codebase into the docker container. As such, we can use this to independently launch a docker container on the robot computer
+FROM ros:galactic
+
+# Install dependencies from apt
+RUN apt-get update && apt-get install -y \
+  # To use git in the container
+  git \
+  # pip is a package manager for Python
+  python3-pip \
+  # To let us sync with GitHub over SSH
+  ssh-client \
+  # Clean out the apt lists after `apt-get update`
+  && rm -rf /var/lib/apt/lists/*
+
+# Update pydocstyle to remove a deprecation warning when testing for PEP257
+RUN pip install --upgrade pydocstyle
+
+# Add a user so we can remote into this container with a non-root user
+RUN useradd trickfire \
+  # Bash will be its default shell
+  --shell /bin/bash \
+  # Give it a directory in /home
+  --create-home \
+  # Don't make a giant log file for login data, we don't care about it
+  --no-log-init
+
+# Copy all the bash customizations over to the user.
+COPY .devcontainer/trickfire.bashrc /home/trickfire/.bashrc
+
+#Copy over the codebase to the user in the urc-2023 folder
+RUN mkdir /home/trickfire/urc-2023
+COPY . /home/trickfire/urc-2023

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #This Dockerfile differs from the .devcontainer/Dockerfile because this one does not depend on VSCode to inject the
 #codebase into the docker container. As such, we can use this to independently launch a docker container on the robot computer
-FROM ros:galactic
+FROM ros:foxy
 
 # Install dependencies from apt
 RUN apt-get update && apt-get install -y \

--- a/docs/run_master_dockerfile.md
+++ b/docs/run_master_dockerfile.md
@@ -1,0 +1,26 @@
+# Running the master Dockerfile
+
+As the other documenations (*[install_on_windows.md](https://github.com/TrickfireRobotics/urc-2023/blob/main/docs/install_on_windows.md), [install_on_linux.md](https://github.com/TrickfireRobotics/urc-2023/blob/main/docs/install_on_linux.md)*) deal with the development container in VSCode, this will deal with running a container without VSCode on an isolated Ubuntu machine.
+
+Specifically, this "master Dockerfile" is meant to be used on the robot in order to run code without the need of VSCode injecting the codebase.
+
+## Setup
+1. Install [Ubuntu 20.04](https://releases.ubuntu.com/focal/) as ROS2 Foxy runs on that version of Ubuntu
+1. Install the [Docker Engine](https://docs.docker.com/engine/install/ubuntu/)
+   1. If you run an issue after running ```sudo apt-get update```, with an error along the lines of ```does not have a Release file```, we need to manually
+   tell which flavor of Docker Engine we need to download for our release of Ubuntu.
+        1. To get your Ubuntu version, run ```lsb_release -a```. The codename should be ```focal``` if you downloaded the correct Ubuntu version.
+        1. Type ```cd /etc/apt/sources.list.d```, then open the ```docker.list``` file by typing ```sudo nano docker.list```. You will most likely be asked for a password.
+        1. Change ```$(lsb_release -cs)``` to ```focal```. Then press ```ctrl + x``` to start exiting, and then press ```y``` to save the file. Then press ```enter/return``` to exit out of the file
+
+## Creating a Docker Image and Docker Container
+1. Download the ```urc-2023``` repo in the ```/home/(your username)/``` directory
+    1. Run ```cd ~``` to get into your home user directory
+    1. Run ```git clone --recurse-submodules https://github.com/TrickfireRobotics/urc-2023.git```
+1. Go into the urc-2023 directory (```cd urc-2023```) and switch to any git branch you want to
+1. Type ```docker build -t trickfireimage .``` This is telling Docker to build an image named ```trickfireimage``` in the same directory that we are in (```/home/(your username)/urc-2023```)
+1. Type ```docker run -it trickfireimage```. This telling docker to run the image ```trickfireimage```, and then give control of the command-line interface (CLI) to that container
+1. You should find that your user CLI has changed to something similar to ```root@(some random numbers and letters)``` 
+1. After this, navigate to the trickfire urc-2023 folder: ```cd /home/trickfire/urc-2023```
+1. Run ```./build.sh``` to build code, and then ```./launch.sh``` to run code
+1. To shutdown this container and go back to the original CLI, type ```exit```.

--- a/docs/run_master_dockerfile.md
+++ b/docs/run_master_dockerfile.md
@@ -1,25 +1,20 @@
 # Running the master Dockerfile
 
-As the other documenations (*[install_on_windows.md](https://github.com/TrickfireRobotics/urc-2023/blob/main/docs/install_on_windows.md), [install_on_linux.md](https://github.com/TrickfireRobotics/urc-2023/blob/main/docs/install_on_linux.md)*) deal with the development container in VSCode, this will deal with running a container without VSCode on an isolated Ubuntu machine.
+As the other documenations (*[install_on_windows.md](https://github.com/TrickfireRobotics/urc-2023/blob/main/docs/install_on_windows.md), [install_on_linux.md](https://github.com/TrickfireRobotics/urc-2023/blob/main/docs/install_on_linux.md)*) deal with the development container in VSCode, this will deal with running a container without VSCode on an isolated Ubuntu machine. The "isolated Ubuntu machine" being the robot computer.
 
-Specifically, this "master Dockerfile" is meant to be used on the robot in order to run code without the need of VSCode injecting the codebase.
+This "master Dockerfile" is meant to be used on the robot computer in order to run code without the need of VSCode injecting/mounting the codebase to the container.
 
-## Setup
+## Setup - Do This Only Once
 1. Install [Ubuntu 20.04](https://releases.ubuntu.com/focal/) as ROS2 Foxy runs on that version of Ubuntu
 1. Install the [Docker Engine](https://docs.docker.com/engine/install/ubuntu/)
-   1. If you run an issue after running ```sudo apt-get update```, with an error along the lines of ```does not have a Release file```, we need to manually
-   tell which flavor of Docker Engine we need to download for our release of Ubuntu.
-        1. To get your Ubuntu version, run ```lsb_release -a```. The codename should be ```focal``` if you downloaded the correct Ubuntu version.
-        1. Type ```cd /etc/apt/sources.list.d```, then open the ```docker.list``` file by typing ```sudo nano docker.list```. You will most likely be asked for a password.
-        1. Change ```$(lsb_release -cs)``` to ```focal```. Then press ```ctrl + x``` to start exiting, and then press ```y``` to save the file. Then press ```enter/return``` to exit out of the file
 
 ## Creating a Docker Image and Docker Container
 1. Download the ```urc-2023``` repo in the ```/home/(your username)/``` directory
     1. Run ```cd ~``` to get into your home user directory
     1. Run ```git clone --recurse-submodules https://github.com/TrickfireRobotics/urc-2023.git```
 1. Go into the urc-2023 directory (```cd urc-2023```) and switch to any git branch you want to
-1. Type ```docker build -t trickfireimage .``` This is telling Docker to build an image named ```trickfireimage``` in the same directory that we are in (```/home/(your username)/urc-2023```)
-1. Type ```docker run -it trickfireimage```. This telling docker to run the image ```trickfireimage```, and then give control of the command-line interface (CLI) to that container
+1. Type ```sudo docker build -t trickfireimage .``` This is telling Docker to build an image named ```trickfireimage``` from the Dockerfile in the same directory that we are in (the urc-2023 root directory)
+1. Type ```sudo docker run -it trickfireimage``` This telling docker to run the image ```trickfireimage```, and then give control of the command-line interface (CLI) to that container
 1. You should find that your user CLI has changed to something similar to ```root@(some random numbers and letters)``` 
 1. After this, navigate to the trickfire urc-2023 folder: ```cd /home/trickfire/urc-2023```
 1. Run ```./build.sh``` to build code, and then ```./launch.sh``` to run code


### PR DESCRIPTION
As the `.devcontainer` folder lacks the ability to build a Docker image with the current codebase on disk without VSCode mounting the codebase (essentially "injecting" it) into the container, the Dockerfile that is in the root project is capable of independently creating a Docker image with the codebase in it.

Essentially, this allows us to not worry about having VSCode installed on the laptop along with any required VSCode plugins in order to run the robot code. 

The general steps of running the code is as follows: 
1. SSH into the robot
1. Do git stuff (git pull/checkout/etc)
1. Build the Docker image on the current git branch `docker build -t trickfireimage`
1. Launch the Docker container from the Docker image `docker run -it trickfireimage`
1. `./build` robot code and then `./launch` the robot code.