### PR TITLE
Make the Docker Container Have a Consistent Name

### DIFF
--- a/connect_to_container.sh
+++ b/connect_to_container.sh
@@ -1,2 +1,2 @@
 #Connect to trickfirerover container
-sudo docker exec -it trickfirerover /bin/bash
+sudo docker exec -it trickfirerobot /bin/bash

--- a/connect_to_container.sh
+++ b/connect_to_container.sh
@@ -1,0 +1,2 @@
+#Connect to trickfirerover container
+sudo docker exec -it trickfirerover /bin/bash

--- a/connect_to_container.sh
+++ b/connect_to_container.sh
@@ -1,2 +1,2 @@
-#Connect to trickfirerover container
+#Connect to trickfirerobot container
 sudo docker exec -it trickfirerobot /bin/bash

--- a/launch_only_docker.sh
+++ b/launch_only_docker.sh
@@ -1,4 +1,4 @@
 #Bind the host machine's urc-2023 root folder to the container's target path.
 #Launch the "trickfireimage" image by giving shell control over to the container
 #Launch the robot code
-docker run --mount type=bind,source="$(pwd)",target="/home/trickfire/urc-2023" -it --privileged --network=host --workdir /home/trickfire/urc-2023 trickfireimage
+docker run --mount type=bind,source="$(pwd)",target="/home/trickfire/urc-2023" --name trickfirerover -it --privileged --network=host --workdir /home/trickfire/urc-2023 trickfireimage

--- a/launch_only_docker.sh
+++ b/launch_only_docker.sh
@@ -1,4 +1,4 @@
 #Bind the host machine's urc-2023 root folder to the container's target path.
 #Launch the "trickfireimage" image by giving shell control over to the container
 #Launch the robot code
-docker run --mount type=bind,source="$(pwd)",target="/home/trickfire/urc-2023" --name trickfirerover -it --privileged --network=host --workdir /home/trickfire/urc-2023 trickfireimage
+docker run --mount type=bind,source="$(pwd)",target="/home/trickfire/urc-2023" --name trickfirerobot -it --privileged --network=host --workdir /home/trickfire/urc-2023 trickfireimage


### PR DESCRIPTION
Added a new shell file named "connect_to_container.sh" to allow an external terminal to connect to the container named "trickfirerobot" and updated the docker run command inside "launch_only_docker.sh" to name the container "trickfirerobot."