### PR TITLE
fix: update project config to resolve vs code linting issues

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,12 @@
                 "ms-python.isort",
                 "ms-python.black-formatter"
             ]
-        }
+        },
+        "settings": {
+        "python.analysis.extraPaths": [
+          "/opt/ros/humble/lib/python3.10/site-packages"
+        ]
+        } 
     }
+    
 }


### PR DESCRIPTION
This commit changes the devcontainer.json to include "/opt/ros/humble/lib/python3.10/site-packages" in the python.analysis.extraPaths. This allows vscode to find the python packages and provide linting.